### PR TITLE
Refactor: centralize shared assets

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,28 @@
+<div class="{{ include.container_class | default: 'container pb-5 d-flex align-items-end justify-content-between flex-wrap' }}">
+  <div class="order-2 order-md-1 mt-5 mt-md-0">
+    <div id="display-cube" class="rounded-circle mb-3"></div>
+    <div>
+      Made with&nbsp; ❤️ &nbsp;by
+      <a class="text-white" href="https://github.com/sentrychris">Chris Rowles</a>
+      &middot; &copy;
+      <script>
+        document.write(new Date().getFullYear());
+      </script>
+    </div>
+  </div>
+  <div class="d-flex flex-column order-1 order-md-2 mt-5 mt-md-0">
+    {% if include.quote %}
+    <em id="quote"></em>
+    {% else %}
+    <span class="ls-2 fs-5">☕ Would you like to hire me?</span>
+    <hr />
+    <span>Email: <a href="mailto:christopher.rowles@outlook.com" class="text-white fw-bold">christopher.rowles@outlook.com</a></span>
+    <span>Phone: <a href="tel:07522267722" class="text-white fw-bold">+44(0)7522 267 722</a></span>
+    {% endif %}
+    <div class="d-flex align-items-center gap-3 mt-3">
+      <a href="https://github.com/sentrychris/"><i class="fa-brands fa-square-github fa-2x" style="color: #cdcdcd"></i></a>
+      <a href="https://www.linkedin.com/in/chris-rowles/"><i class="fa-brands fa-linkedin fa-2x" style="color: #cdcdcd"></i></a>
+      <a href="https://www.linkedin.com/in/chris-rowles/"><i class="fa-brands fa-y-combinator fa-2x" style="color: #cdcdcd"></i></a>
+    </div>
+  </div>
+</div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,15 @@
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+<link
+  rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
+  integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
+  crossorigin="anonymous"
+  referrerpolicy="no-referrer"
+/>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Montserrat&family=Open+Sans&family=Noto+Sans&family=Oxygen&family=Manrope&family=Nunito&family=Poppins&display=swap"
+  rel="stylesheet"
+/>
+<link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}" />

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,0 +1,2 @@
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="{{ '/assets/script.js' | relative_url }}"></script>

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,31 @@
+document.addEventListener("DOMContentLoaded", () => {
+    if (window.particlesJS) {
+        particlesJS.load("particles-js", "assets/particles-2.json", function () {
+            console.log("particles.js config loaded");
+        });
+    }
+
+    const quotesEl = document.getElementById("quote");
+    if (quotesEl) {
+        const quotes = [
+            "Simplicity is the ultimate sophistication.",
+            "What you seek is seeking you.",
+            "Do what you can, with what you have, where you are.",
+            "In the middle of difficulty lies opportunity.",
+            "Act as if what you do makes a difference. It does.",
+            "Not all those who wander are lost.",
+            "Happiness depends upon ourselves."
+        ];
+        quotesEl.textContent = quotes[Math.floor(Math.random() * quotes.length)];
+    }
+
+    document.addEventListener('click', function (e) {
+        const img = e.target.closest('img[data-bs-target="#imageModal"]');
+        if (!img) return;
+        const modalImg = document.getElementById('imageModalImg');
+        if (modalImg) {
+            modalImg.src = img.getAttribute('data-full') || img.src;
+            modalImg.alt = img.alt || '';
+        }
+    });
+});

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,120 @@
+/* Shared styles */
+.bd-placeholder-img {
+    font-size: 1.125rem;
+    text-anchor: middle;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    user-select: none;
+}
+@media (min-width: 768px) {
+    .bd-placeholder-img-lg {
+        font-size: 3.5rem;
+    }
+}
+body {
+    font-family: "Open Sans", sans-serif;
+    color: #444444;
+}
+a {
+    color: #383f5f;
+}
+a:hover {
+    color: #545c86;
+    font-weight: bold;
+    text-decoration: none;
+}
+.icon-list {
+    padding-left: 0;
+    list-style: none;
+}
+.icon-list li {
+    display: flex;
+    align-items: flex-start;
+    margin-bottom: 0.25rem;
+}
+.icon-list li::before {
+    display: block;
+    flex-shrink: 0;
+    width: 1.5em;
+    height: 1.5em;
+    margin-right: 0.5rem;
+    content: "";
+    background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23435D4F' viewBox='0 0 16 16'%3E%3Cpath d='M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0zM4.5 7.5a.5.5 0 0 0 0 1h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5H4.5z'/%3E%3C/svg%3E") no-repeat center center / 100% auto;
+}
+svg:not(:root).svg-inline--fa {
+    overflow: visible;
+}
+.svg-inline--fa.fa-w-16 {
+    width: 1em;
+}
+.love {
+    color: #212529;
+}
+.svg-inline--fa {
+    display: inline-block;
+    font-size: inherit;
+    height: 1em;
+    overflow: visible;
+    vertical-align: -0.125em;
+}
+.filename {
+    font-size: 0.6em;
+}
+.github-fork-ribbon:before {
+    background-color: #212529;
+}
+.version-info,
+.release-info {
+    font-size: 0.75rem;
+    margin-bottom: 0;
+}
+.text-left {
+    text-align: left;
+}
+.heading {
+    color: #545c86;
+    font-weight: 400;
+}
+.heading__sub-heading {
+    color: #555555;
+}
+.bg-black-grad {
+    background: linear-gradient(135deg, #45336d 0%, #191818 100%);
+}
+.overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: url("./filter.png");
+    background-repeat: repeat;
+    opacity: 0.5;
+}
+#particles-js {
+    z-index: 1 !important;
+}
+.btn-download {
+    background: linear-gradient(135deg, #45336d 0%, #411f1f 100%);
+    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
+    color: #fff;
+    letter-spacing: 1px;
+    padding: 12px 16px;
+    transition: all 0.2s ease-in-out;
+}
+.btn-download:hover {
+    transform: scale(1.025);
+    color: #fff;
+    box-shadow: 0 16px 30px rgba(0, 0, 0, 0.15);
+}
+.project-card {
+    border: 1px solid #e7e7e7;
+    border-radius: 12px;
+    transition: transform 0.15s ease;
+}
+.project-card:hover {
+    transform: translateY(-2px);
+}
+.badge-row img {
+    height: 20px;
+}

--- a/index.html
+++ b/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -32,24 +34,7 @@
     <title>Versyx Digital — Open Source Studio</title>
 
     <link rel="canonical" href="https://versyxdigital.github.io/" />
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-    />
-    <link rel="stylesheet" href="./assets/style.css" />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
-      integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat&family=Open+Sans&family=Noto+Sans&family=Oxygen&family=Manrope&family=Nunito&family=Poppins&display=swap"
-      rel="stylesheet"
-    />
+    {% include head.html %}
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css"
@@ -274,34 +259,11 @@
       </div>
     </section>
 
-    <footer class="position-relative pt-5 bg-black-grad text-white small">
-      <div class="overlay z-2"></div>
-      <div class="container position-relative z-3 pb-5 d-flex align-items-end justify-content-between flex-wrap">
-        <div class="order-2 order-md-1 mt-5 mt-md-0">
-          <div id="display-cube" class="rounded-circle mb-3"></div>
-          <div>
-            Made with&nbsp; ❤️ &nbsp;by
-            <a class="text-white" href="https://github.com/sentrychris">Chris Rowles</a>
-            &middot; &copy;
-            <script>
-              document.write(new Date().getFullYear());
-            </script>
-          </div>
-        </div>
-        <div class="d-flex flex-column order-1 order-md-2 mt-5 mt-md-0">
-          <em id="quote"></em>
-          <div class="d-flex align-items-center gap-3 mt-3">
-            <a href="https://github.com/sentrychris/"><i class="fa-brands fa-square-github fa-2x" style="color: #cdcdcd"></i></a>
-            <a href="https://www.linkedin.com/in/chris-rowles/"><i class="fa-brands fa-linkedin fa-2x" style="color: #cdcdcd"></i></a>
-            <a href="https://www.linkedin.com/in/chris-rowles/"><i class="fa-brands fa-y-combinator fa-2x" style="color: #cdcdcd"></i></a>
-          </div>
-        </div>
-      </div>
-    </footer>
+      <footer class="position-relative pt-5 bg-black-grad text-white small">
+        <div class="overlay z-2"></div>
+        {% include footer.html quote=true container_class="container position-relative z-3 pb-5 d-flex align-items-end justify-content-between flex-wrap" %}
+      </footer>
 
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
-    ></script>
-    <script src="./assets/script.js"></script>
+    {% include scripts.html %}
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css"
       rel="stylesheet"
     />
+    <link rel="stylesheet" href="./assets/style.css" />
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
@@ -76,72 +77,6 @@
       }
     </script>
 
-    <style>
-      body {
-        font-family: "Open Sans", sans-serif;
-        color: #444444;
-      }
-      a {
-        color: #383f5f;
-      }
-      a:hover {
-        color: #545c86;
-        font-weight: bold;
-        text-decoration: none;
-      }
-      .bg-black-grad {
-        background: linear-gradient(135deg, #45336d 0%, #191818 100%);
-      }
-      .github-fork-ribbon:before {
-        background-color: #212529;
-      }
-      .heading {
-        color: #545c86;
-        font-weight: 400;
-      }
-      .overlay {
-        position: absolute;
-        top: 0;
-        right: 0;
-        bottom: 0;
-        left: 0;
-        background: url(./assets/filter.png);
-        background-repeat: repeat;
-        opacity: 0.5;
-      }
-      #particles-js {
-        z-index: 1 !important;
-      }
-      .btn-download {
-        background: linear-gradient(135deg, #45336d 0%, #411f1f 100%);
-        box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
-        color: #fff;
-        letter-spacing: 1px;
-        padding: 12px 16px;
-        transition: all 0.2s ease-in-out;
-      }
-      .btn-download:hover {
-        transform: scale(1.025);
-        color: #fff;
-        box-shadow: 0 16px 30px rgba(0, 0, 0, 0.15);
-      }
-      .project-card {
-        border: 1px solid #e7e7e7;
-        border-radius: 12px;
-        transition: transform 0.15s ease;
-      }
-      .project-card:hover {
-        transform: translateY(-2px);
-      }
-      .badge-row img {
-        height: 20px;
-      }
-      .version-info,
-      .release-info {
-        font-size: 0.75rem;
-        margin-bottom: 0;
-      }
-    </style>
     <script src="https://kit.fontawesome.com/5475e8a6de.js" crossorigin="anonymous"></script>
   </head>
   <body class="h-100">
@@ -367,32 +302,6 @@
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
     ></script>
-
-    <script>
-      particlesJS.load("particles-js", "assets/particles-2.json", function () {
-        console.log("particles.js config loaded");
-      });
-
-      const quotes = [
-        "Simplicity is the ultimate sophistication.",
-        "What you seek is seeking you.",
-        "Do what you can, with what you have, where you are.",
-        "In the middle of difficulty lies opportunity.",
-        "Act as if what you do makes a difference. It does.",
-        "Not all those who wander are lost.",
-        "Happiness depends upon ourselves."
-      ];
-
-      document.getElementById("quote").textContent = quotes[Math.floor(Math.random() * quotes.length)];
-
-      document.addEventListener('click', function (e) {
-        const img = e.target.closest('img[data-bs-target="#imageModal"]');
-        if (!img) return;
-
-        const modalImg = document.getElementById('imageModalImg');
-        modalImg.src = img.getAttribute('data-full') || img.src; // use full-size if provided
-        modalImg.alt = img.alt || '';
-      });
-    </script>
+    <script src="./assets/script.js"></script>
   </body>
 </html>

--- a/mkeditor/assets/script.js
+++ b/mkeditor/assets/script.js
@@ -1,0 +1,1 @@
+// MKEditor specific scripts

--- a/mkeditor/assets/style.css
+++ b/mkeditor/assets/style.css
@@ -1,0 +1,42 @@
+.bg-black-grad {
+    background: linear-gradient(135deg, #404040 0%, #000000 100%);
+}
+.btn-download {
+    background: #519088;
+    background: linear-gradient(-70deg, #323534, #656565);
+    box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
+    color: white;
+    text-decoration: none;
+    letter-spacing: 1px;
+    padding: 15px;
+    transition: all .2s ease-in-out;
+}
+.btn-download:hover {
+    transform: scale(1.025);
+    color: white;
+    font-weight: bold;
+    box-shadow: 0px 16px 30px rgba(0, 0, 0, 0.1);
+}
+.btn-edit {
+    background: transparent;
+    box-shadow: none;
+    color: #212529;
+    font-weight: bold;
+    text-decoration: none;
+    letter-spacing: 1px;
+    padding: 15px;
+    transition: all 0.2s ease-in-out;
+}
+.btn-edit:hover {
+    color: #545c86;
+}
+.btn-web {
+    color: #316d65;
+}
+.btn-web:hover {
+    color: #118374;
+}
+.settings-list li {
+    margin-bottom: 20px;
+    font-size: 0.9rem;
+}

--- a/mkeditor/index.html
+++ b/mkeditor/index.html
@@ -30,6 +30,8 @@
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Montserrat&family=Open+Sans&family=Noto+Sans&family=Oxygen&family=Manrope&family=Nunito&family=Poppins&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css">
+        <link rel="stylesheet" href="../assets/style.css">
+        <link rel="stylesheet" href="./assets/style.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/regl/2.1.1/regl.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/3.4.2/gl-matrix-min.js"></script>
         <script src="./assets/particles.min.js"></script>
@@ -52,136 +54,6 @@
         </script>
 
 
-        <style>
-            .bd-placeholder-img {
-                font-size: 1.125rem;
-                text-anchor: middle;
-                -webkit-user-select: none;
-                -moz-user-select: none;
-                user-select: none;
-            }
-            @media (min-width: 768px) {
-                .bd-placeholder-img-lg {
-                    font-size: 3.5rem;
-                }
-            }
-            body {
-                font-family: "Open Sans", sans-serif;
-                color: #444444
-            }
-            a:hover {
-                color: white;
-                text-decoration: none;
-            }
-            .bg-black-grad {
-                background: linear-gradient(135deg, #404040 0%, #000000 100%);
-            }
-            .icon-list {
-                padding-left: 0;
-                list-style: none;
-            }
-            .icon-list li {
-                display: flex;
-                align-items: flex-start;
-                margin-bottom: 0.25rem;
-            }
-            .icon-list li::before {
-                display: block;
-                flex-shrink: 0;
-                width: 1.5em;
-                height: 1.5em;
-                margin-right: 0.5rem;
-                content: "";
-                background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23435D4F' viewBox='0 0 16 16'%3E%3Cpath d='M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0zM4.5 7.5a.5.5 0 0 0 0 1h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5H4.5z'/%3E%3C/svg%3E")
-                    no-repeat center center / 100% auto;
-            }
-            svg:not(:root).svg-inline--fa {
-                overflow: visible;
-            }
-            .svg-inline--fa.fa-w-16 {
-                width: 1em;
-            }
-            .love {
-                color: #212529;
-            }
-            .svg-inline--fa {
-                display: inline-block;
-                font-size: inherit;
-                height: 1em;
-                overflow: visible;
-                vertical-align: -0.125em;
-            }
-            .filename {
-                font-size: 0.6em;
-            }
-            .github-fork-ribbon:before {
-                background-color: #212529;
-            }
-            .version-info {
-                font-size: 0.65rem;
-                margin-bottom: 0;
-            }
-            .release-info {
-                font-size: 0.75rem;
-                margin-bottom: 0;
-            }
-            a {
-                color: #383f5f;
-            }
-            a:hover {
-                color: #545c86;
-                font-weight: bold;
-            }
-            .text-left {
-                text-align: left;
-            }
-            .heading {
-                color: #545c86;
-                font-weight: 400;
-            }
-            .heading__sub-heading {
-                color: #555555;
-            }
-            .btn-download {
-                background: #519088;
-                background: linear-gradient(-70deg, #323534, #656565);
-                box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
-                color: white;
-                text-decoration: none;
-                letter-spacing: 1px;
-                padding: 15px;
-                transition: all .2s ease-in-out;
-            }
-            .btn-download:hover {
-                transform: scale(1.025);
-                color: white;
-                font-weight: bold;
-                box-shadow: 0px 16px 30px rgba(0, 0, 0, 0.1);
-            }
-            .btn-edit {
-                background: transparent;
-                box-shadow: none;
-                color: #212529;
-                font-weight: bold;
-                text-decoration: none;
-                letter-spacing: 1px;
-                padding: 15px;
-                transition: all 0.2s ease-in-out;
-            }
-            .btn-edit:hover {
-                color: #545c86;
-            }
-            .btn-web {
-                color: #316d65;
-            }
-            .btn-web:hover {
-                color: #118374;
-            }
-            .settings-list li {
-                margin-bottom: 20px;
-                font-size: 0.9rem;
-            }
-        </style>
         <script src="https://kit.fontawesome.com/5475e8a6de.js" crossorigin="anonymous"></script>
     </head>
     <body class="h-100">
@@ -522,19 +394,8 @@
             </footer>
         </div>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
+        <script src="../assets/script.js"></script>
+        <script src="./assets/script.js"></script>
 
-        <script>
-            particlesJS.load("particles-js", "assets/particles-2.json", function () {
-                console.log("callback - particles.js config loaded");
-            });
-            document.addEventListener('click', function (e) {
-                const img = e.target.closest('img[data-bs-target="#imageModal"]');
-                if (!img) return;
-
-                const modalImg = document.getElementById('imageModalImg');
-                modalImg.src = img.getAttribute('data-full') || img.src; // use full-size if provided
-                modalImg.alt = img.alt || '';
-            });
-        </script>
     </body>
 </html>

--- a/mkeditor/index.html
+++ b/mkeditor/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -18,20 +20,9 @@
         <title>MKEditor - Simple & Fast Online Markdown Editor with Live Preview</title>
 
         <link rel="canonical" href="https://versyxdigital.github.io/mkeditor/">
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-        <link
-            rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
-            integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
-            crossorigin="anonymous"
-            referrerpolicy="no-referrer"
-        >
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat&family=Open+Sans&family=Noto+Sans&family=Oxygen&family=Manrope&family=Nunito&family=Poppins&display=swap" rel="stylesheet">
+        {% include head.html %}
+        <link rel="stylesheet" href="{{ '/mkeditor/assets/style.css' | relative_url }}">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css">
-        <link rel="stylesheet" href="../assets/style.css">
-        <link rel="stylesheet" href="./assets/style.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/regl/2.1.1/regl.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/3.4.2/gl-matrix-min.js"></script>
         <script src="./assets/particles.min.js"></script>
@@ -363,39 +354,11 @@
             </section>
 
             <footer class="pt-5 text-white small" style="background: linear-gradient(135deg, #404040 0%, #000000 100%);">
-                <div class="container pb-5 d-flex align-items-end justify-content-between flex-wrap">
-                    <div class="order-2 order-md-1 mt-5 mt-md-0">
-                        <div id="display-cube" class="rounded-circle mb-3"></div>
-                        <div>
-                            Made with&nbsp; ❤️ &nbsp;by <a class="text-white" href="https://github.com/sentrychris">Chris Rowles</a> &middot; &copy;
-                            <script>
-                                document.write(new Date().getFullYear());
-                            </script>
-                        </div>
-                    </div>
-                    <div class="d-flex flex-column order-1 order-md-2 mt-5 mt-md-0">
-                        <span class="ls-2 fs-5">☕ Would you like to hire me?</span>
-                        <hr>
-                        <span>Email: <a href="mailto:christopher.rowles@outlook.com" class="text-white fw-bold">christopher.rowles@outlook.com</a></span>
-                        <span>Phone: <a href="tel:07522267722" class="text-white fw-bold">+44(0)7522 267 722</a></span>
-                        <div class="d-flex align-items-center gap-3 mt-3">
-                            <a href="https://github.com/sentrychris/">
-                                <i class="fa-brands fa-square-github fa-2x" style="color: #b3b3b3"></i>
-                            </a>
-                            <a href="https://www.linkedin.com/in/chris-rowles/">
-                                <i class="fa-brands fa-linkedin fa-2x" style="color: #b3b3b3"></i>
-                            </a>
-                            <a href="https://www.linkedin.com/in/chris-rowles/">
-                                <i class="fa-brands fa-y-combinator fa-2x" style="color: #b3b3b3"></i>
-                            </a>
-                        </div>
-                    </div>
-                </div>
+                {% include footer.html container_class="container pb-5 d-flex align-items-end justify-content-between flex-wrap" %}
             </footer>
         </div>
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
-        <script src="../assets/script.js"></script>
-        <script src="./assets/script.js"></script>
+        {% include scripts.html %}
+        <script src="{{ '/mkeditor/assets/script.js' | relative_url }}"></script>
 
     </body>
 </html>

--- a/psmonitor/assets/script.js
+++ b/psmonitor/assets/script.js
@@ -1,0 +1,1 @@
+// PSMonitor specific scripts

--- a/psmonitor/assets/style.css
+++ b/psmonitor/assets/style.css
@@ -1,0 +1,35 @@
+body {
+    font-family: "Montserrat", sans-serif;
+}
+.btn-download {
+    background: linear-gradient(-70deg, #545c86, #6d7194);
+    box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
+    color: white;
+    text-decoration: none;
+    letter-spacing: 1px;
+    padding: 15px;
+    transition: all 0.2s ease-in-out;
+}
+.btn-download:hover {
+    transform: scale(1.025);
+    color: white;
+    font-weight: bold;
+    box-shadow: 0px 16px 30px rgba(0, 0, 0, 0.1);
+}
+.btn-edit {
+    background: transparent;
+    box-shadow: none;
+    color: #212529;
+    font-weight: bold;
+    text-decoration: none;
+    letter-spacing: 1px;
+    padding: 15px;
+    transition: all 0.2s ease-in-out;
+}
+.btn-edit:hover {
+    color: #545c86;
+}
+.settings-list li {
+    margin-bottom: 20px;
+    font-size: 0.9rem;
+}

--- a/psmonitor/index.html
+++ b/psmonitor/index.html
@@ -21,130 +21,12 @@
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Montserrat&family=Open+Sans&family=Noto+Sans&family=Oxygen&family=Manrope&family=Nunito&family=Poppins&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css">
+        <link rel="stylesheet" href="../assets/style.css">
+        <link rel="stylesheet" href="./assets/style.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/regl/2.1.1/regl.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/3.4.2/gl-matrix-min.js"></script>
         <script src="./assets/particles.min.js"></script>
 
-        <style>
-            .bd-placeholder-img {
-                font-size: 1.125rem;
-                text-anchor: middle;
-                -webkit-user-select: none;
-                -moz-user-select: none;
-                user-select: none;
-            }
-            @media (min-width: 768px) {
-                .bd-placeholder-img-lg {
-                    font-size: 3.5rem;
-                }
-            }
-            body {
-                font-family: "Montserrat", sans-serif;
-            }
-            a:hover {
-                color: white;
-                text-decoration: none;
-            }
-            .icon-list {
-                padding-left: 0;
-                list-style: none;
-            }
-            .icon-list li {
-                display: flex;
-                align-items: flex-start;
-                margin-bottom: 0.25rem;
-            }
-            .icon-list li::before {
-                display: block;
-                flex-shrink: 0;
-                width: 1.5em;
-                height: 1.5em;
-                margin-right: 0.5rem;
-                content: "";
-                background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='%23435D4F' viewBox='0 0 16 16'%3E%3Cpath d='M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0zM4.5 7.5a.5.5 0 0 0 0 1h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5H4.5z'/%3E%3C/svg%3E")
-                    no-repeat center center / 100% auto;
-            }
-            svg:not(:root).svg-inline--fa {
-                overflow: visible;
-            }
-            .svg-inline--fa.fa-w-16 {
-                width: 1em;
-            }
-            .love {
-                color: #212529;
-            }
-            .svg-inline--fa {
-                display: inline-block;
-                font-size: inherit;
-                height: 1em;
-                overflow: visible;
-                vertical-align: -0.125em;
-            }
-            .filename {
-                font-size: 0.6em;
-            }
-            .github-fork-ribbon:before {
-                background-color: #212529;
-            }
-            .version-info {
-                font-size: 0.65rem;
-                margin-bottom: 0;
-            }
-            .release-info {
-                font-size: 0.75rem;
-                margin-bottom: 0;
-            }
-            a {
-                color: #383f5f;
-            }
-            a:hover {
-                color: #545c86;
-                font-weight: bold;
-            }
-            .text-left {
-                text-align: left;
-            }
-            .heading {
-                color: #545c86;
-                font-weight: 400;
-            }
-            .heading__sub-heading {
-                color: #555555;
-            }
-            .btn-download {
-                /* background: #519088; */
-                background: linear-gradient(-70deg, #545c86, #6d7194);
-                box-shadow: 0px 8px 15px rgba(0, 0, 0, 0.1);
-                color: white;
-                text-decoration: none;
-                letter-spacing: 1px;
-                padding: 15px;
-                transition: all 0.2s ease-in-out;
-            }
-            .btn-download:hover {
-                transform: scale(1.025);
-                color: white;
-                font-weight: bold;
-                box-shadow: 0px 16px 30px rgba(0, 0, 0, 0.1);
-            }
-            .btn-edit {
-                background: transparent;
-                box-shadow: none;
-                color: #212529;
-                font-weight: bold;
-                text-decoration: none;
-                letter-spacing: 1px;
-                padding: 15px;
-                transition: all 0.2s ease-in-out;
-            }
-            .btn-edit:hover {
-                color: #545c86;
-            }
-            .settings-list li {
-                margin-bottom: 20px;
-                font-size: 0.9rem;
-            }
-        </style>
         <script src="https://kit.fontawesome.com/5475e8a6de.js" crossorigin="anonymous"></script>
     </head>
     <body class="h-100">
@@ -382,11 +264,7 @@
             </footer>
         </div>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
-
-        <script>
-            particlesJS.load("particles-js", "assets/particles-2.json", function () {
-                console.log("callback - particles.js config loaded");
-            });
-        </script>
+        <script src="../assets/script.js"></script>
+        <script src="./assets/script.js"></script>
     </body>
 </html>

--- a/psmonitor/index.html
+++ b/psmonitor/index.html
@@ -1,3 +1,5 @@
+---
+---
 <!DOCTYPE html>
 <html lang="en">
     <head>
@@ -9,20 +11,9 @@
         <meta property="og:description" content="Quickly and easily monitor your system health. A built-in websocket server is also included for remote monitoring capabilities.">
         <meta property="og:image" content="https://versyxdigital.github.io/psmonitor/demo.png">
         <title>PSMonitor - A simple monitoring utility.</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
-        <link
-            rel="stylesheet"
-            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
-            integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg=="
-            crossorigin="anonymous"
-            referrerpolicy="no-referrer"
-        >
-        <link rel="preconnect" href="https://fonts.googleapis.com">
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat&family=Open+Sans&family=Noto+Sans&family=Oxygen&family=Manrope&family=Nunito&family=Poppins&display=swap" rel="stylesheet">
+        {% include head.html %}
+        <link rel="stylesheet" href="{{ '/psmonitor/assets/style.css' | relative_url }}">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.min.css">
-        <link rel="stylesheet" href="../assets/style.css">
-        <link rel="stylesheet" href="./assets/style.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/regl/2.1.1/regl.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/gl-matrix/3.4.2/gl-matrix-min.js"></script>
         <script src="./assets/particles.min.js"></script>
@@ -233,38 +224,10 @@
             </section>
 
             <footer class="pt-5 text-white small" style="background: linear-gradient(135deg, #000000 0%, #181b27 100%);">
-                <div class="container pb-5 d-flex align-items-end justify-content-between">
-                    <div>
-                        <div id="display-cube" class="rounded-circle mb-3"></div>
-                        <div>
-                            Made with&nbsp; ❤️ &nbsp;by <a class="text-white" href="https://versyx.dev">Chris Rowles</a> &middot; &copy;
-                            <script>
-                                document.write(new Date().getFullYear());
-                            </script>
-                        </div>
-                    </div>
-                    <div class="d-flex flex-column">
-                        <span class="ls-2 fs-5">☕ Would you like to hire me?</span>
-                        <hr>
-                        <span>Email: <a href="mailto:christopher.rowles@outlook.com" class="text-white fw-bold">christopher.rowles@outlook.com</a></span>
-                        <span>Phone: <a href="tel:07522267722" class="text-white fw-bold">+44(0)7522 267 722</a></span>
-                        <div class="d-flex align-items-center gap-3 mt-3">
-                            <a href="https://github.com/sentrychris/">
-                                <i class="fa-brands fa-square-github fa-2x text-white"></i>
-                            </a>
-                            <a href="https://www.linkedin.com/in/chris-rowles/">
-                                <i class="fa-brands fa-linkedin fa-2x text-white"></i>
-                            </a>
-                            <a href="https://www.linkedin.com/in/chris-rowles/">
-                                <i class="fa-brands fa-y-combinator fa-2x text-white"></i>
-                            </a>
-                        </div>
-                    </div>
-                </div>
+                {% include footer.html container_class="container pb-5 d-flex align-items-end justify-content-between" %}
             </footer>
         </div>
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
-        <script src="../assets/script.js"></script>
-        <script src="./assets/script.js"></script>
+        {% include scripts.html %}
+        <script src="{{ '/psmonitor/assets/script.js' | relative_url }}"></script>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- extract shared styles and scripts into `assets/style.css` and `assets/script.js`
- add app-specific `assets` folders for MKEditor and PSMonitor
- update pages to reference shared resources

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e5c09cba8832390faafd7527253c0